### PR TITLE
feat: add Hooks Extension Framework tooling for filters

### DIFF
--- a/docs/decisions/0002-hooks-filter-config-location.rst
+++ b/docs/decisions/0002-hooks-filter-config-location.rst
@@ -1,0 +1,98 @@
+Configuration for filters in the Hooks Extension Framework
+==========================================================
+
+Status
+------
+
+Draft
+
+Context
+-------
+
+Context taken from the Discuss thread `Configuration for the Hooks Extension Framework <https://discuss.openedx.org/t/configuration-for-the-hooks-extension-framework/4527>`_
+
+We need a way to configure a list of functions (filters) that will be called at different places (triggers) in the code of edx-platform.
+
+So, for a string like:
+
+"openedx.lms.auth.pre_register.filter.v1"
+
+We need to define a list of functions:
+
+.. code-block:: python
+
+    [
+        "from_a_plugin.filters.filter_1",
+        "from_a_plugin.filters.filter_n",
+        "from_some_other_package.filters.filter_1",
+        # ... and so.
+    ]
+
+
+We have considered two alternatives:
+
+* A dict in the Django settings.
+    * Advantages:
+        * It is very standard, everyone should know how to change it by now.
+        * Can be altered without installing plugins.
+    * Disadvantages:
+        * It is hard to document a large dict.
+        * Could grow into something difficult to manage.
+
+* In a view of the AppConfig of your plugin.
+    * Advantages:
+        * Each plugin can extend the config to add its own filters without collisions.
+    * Disadvantages:
+        * It’s not possible to control the ordering of different filters being connected to the same trigger by different plugins.
+        * For updates, an operator must install a new version of the dependency which usually is longer and more difficult than changing vars and restart.
+        * Not easy to configure by tenant if you use site configs.
+        * Requires a plugin.
+
+Decision
+--------
+
+We decided to use a dictionary with a flexible format defined using Django settings.
+
+Consequences
+------------
+
+1. The only way to configure Hooks Extension Framework is via Django settings using one of these three formats:
+
+**Option 1**: this is the more detailed option and from it, the others can be derived. Through this configuration can be configured the list of functions to be executed.
+to execute them.
+
+.. code-block:: python
+
+    HOOKS_EXTENSION_CONFIG = {
+        "openedx.service.trigger_context.location.trigger_type.vi": {
+            "pipeline": [
+                "from_a_plugin.filters.filter_1",
+                "from_a_plugin.filters.filter_n",
+                "from_some_other_package.filters.filter_1",
+            ],
+        }
+    }
+
+**Option 2**: this option only considers the configuration of the list of functions to be executed.
+
+.. code-block:: python
+
+    HOOKS_EXTENSION_CONFIG = {
+        "openedx.service.trigger_context.location.trigger_type.vi": {
+            [
+                "from_a_plugin.filters.filter_1",
+                "from_a_plugin.filters.filter_n",
+                "from_some_other_package.filters.filter_1",
+            ],
+        }
+    }
+
+**Option 3**: this option considers that there's just one function to be executed.
+
+.. code-block:: python
+
+    HOOKS_EXTENSION_CONFIG = {
+        "openedx.service.trigger_context.location.trigger_type.vi": "from_a_plugin.filters.filter_1",
+    }
+
+2. Given that Site Configurations is not available in this repository, it can't be used to configure hooks.

--- a/docs/decisions/0003-hooks-filter-tooling-pipeline.rst
+++ b/docs/decisions/0003-hooks-filter-tooling-pipeline.rst
@@ -1,0 +1,43 @@
+Hooks tooling: pipeline for filters
+===================================
+
+Status
+------
+
+Draft
+
+Context
+-------
+
+Taking into account the design considerations outlined in OEP-50 Hooks extension framework about
+
+1. The order of execution for multiple actions must be respected
+2. The result of a previous function must be available to the current one
+
+We must implement a pattern that follows this considerations: a Pipeline for the set of functions, i.e filters,
+listening on a trigger.
+
+Checkout https://github.com/edx/open-edx-proposals/pull/184 for more information.
+
+To do this, we considered three similar approaches for the pipeline implementation:
+
+1. Unix-like (how unix pipe operator works): the output of the previous function is the input of the next one. For the first function, includes the initial arguments.
+2. Unix-like modified: the output of the previous function is the input of the next one including the initial arguments for all functions.
+3. Accumulative: the output of every (i, …, i-n) function is accumulated using a data structure and fed into the next function i-n+1, including the initial arguments. We draw inspiration from
+   python-social-auth/social-core, please checkout their repository: https://github.com/python-social-auth/social-core
+
+These approaches follow the pipeline pattern and have as main difference what each function receive as input.
+
+It is important to emphasize that the main objectives with this implementation are: to have function interchangeability and to maintain the signature of the functions across the Hooks Extension Framework.
+
+Decision
+--------
+
+We decided to use the accumulative approach as the only pipeline for filters.
+
+Consequences
+------------
+
+1. The order of execution is maintained.
+2. Given that all pipeline functions will expect the same input arguments, i.e accumulated output plus initial arguments, their signature will stay the same. And for this reason, these functions are interchangeable.
+3. For the above reason, filters must have \*args and \*\*kwargs in their signature.

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""
+Django administration utility.
+"""
+
+import os
+import sys
+
+PWD = os.path.abspath(os.path.dirname(__file__))
+
+if __name__ == '__main__':
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_utils.test_settings')
+    sys.path.append(PWD)
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other
+        # exceptions on Python 2.
+        try:
+            import django  # pylint: disable=unused-import
+        except ImportError as error:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            ) from error
+        raise
+    execute_from_command_line(sys.argv)

--- a/openedx_hooks/filters/__init__.py
+++ b/openedx_hooks/filters/__init__.py
@@ -1,0 +1,4 @@
+"""
+File used to expose available triggers.
+"""
+from .triggers import trigger_filter

--- a/openedx_hooks/filters/exceptions.py
+++ b/openedx_hooks/filters/exceptions.py
@@ -5,17 +5,25 @@ Exceptions thrown by Hooks.
 
 class HookException(Exception):
     """
-    Base exception for hooks. It is re-raised by the Pipeline Runner if any of
-    the actions/filters that is executing raises it.
+    Base exception for hooks.
+
+    It is re-raised by the Pipeline Runner if any filter that is
+    executing raises it.
 
     Arguments:
         message (str): message describing why the exception was raised.
         redirect_to (str): redirect URL.
         status_code (int): HTTP status code.
-        keyword arguments (kwargs): extra arguments used to customize exception.
+        keyword arguments (kwargs): extra arguments used to customize
+        exception.
     """
 
     def __init__(self, message="", redirect_to=None, status_code=None, **kwargs):
+        """
+        Init method for HookException.
+
+        It's designed to allow flexible instantiation through **kwargs.
+        """
         super().__init__()
         self.message = message
         self.redirect_to = redirect_to
@@ -24,4 +32,7 @@ class HookException(Exception):
             setattr(self, key, value)
 
     def __str__(self):
+        """
+        Show string representation of HookException using its message.
+        """
         return "HookException: {}".format(self.message)

--- a/openedx_hooks/filters/exceptions.py
+++ b/openedx_hooks/filters/exceptions.py
@@ -1,0 +1,27 @@
+"""
+Exceptions thrown by Hooks.
+"""
+
+
+class HookException(Exception):
+    """
+    Base exception for hooks. It is re-raised by the Pipeline Runner if any of
+    the actions/filters that is executing raises it.
+
+    Arguments:
+        message (str): message describing why the exception was raised.
+        redirect_to (str): redirect URL.
+        status_code (int): HTTP status code.
+        keyword arguments (kwargs): extra arguments used to customize exception.
+    """
+
+    def __init__(self, message="", redirect_to=None, status_code=None, **kwargs):
+        super().__init__()
+        self.message = message
+        self.redirect_to = redirect_to
+        self.status_code = status_code
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def __str__(self):
+        return "HookException: {}".format(self.message)

--- a/openedx_hooks/filters/pipeline.py
+++ b/openedx_hooks/filters/pipeline.py
@@ -11,8 +11,11 @@ log = getLogger(__name__)
 
 def run_pipeline(pipeline, *args, raise_exception=False, **kwargs):
     """
-    Given a list of functions paths, this function  will execute them using the Accumulative Pipeline
-    pattern defined in docs/decisions/0006-hooks-tooling-pipeline.rst
+    Execute filters in order.
+
+    Given a list of functions paths, this function will execute
+    them using the Accumulative Pipeline pattern defined in
+    docs/decisions/0003-hooks-filter-tooling-pipeline.rst
 
     Example usage:
         result = run_pipeline(
@@ -34,20 +37,23 @@ def run_pipeline(pipeline, *args, raise_exception=False, **kwargs):
         pipeline (list): paths where each function is defined.
 
     Keyword arguments:
-        raise_exception (bool): used to determine whether the pipeline will raise HookExceptions. Default is set
-        to False.
+        raise_exception (bool): used to determine whether the pipeline will
+        raise HookExceptions. Default is set to False.
 
     Returns:
         out (dict): accumulated outputs of the functions defined in pipeline.
-        result (obj): return object of one of the pipeline functions. This will be the return object for the pipeline
-        if one of the functions returns an object different than Dict o None.
+        result (obj): return object of one of the pipeline functions. This will
+        be the returned by the pipeline if one of the functions returns
+        an object different than Dict o None.
 
     Exceptions raised:
-        HookException: custom exception re-raised when a function raised an exception of
-        this type and raise_exception is set to True. This behavior is common when using filters.
+        HookException: custom exception re-raised when a function raised an
+        exception of this type and raise_exception is set to True. This
+        behavior is common when using filters.
 
-    This pipeline implementation was inspired by: Social auth core. For more information check their Github
-    repository: https://github.com/python-social-auth/social-core
+    This pipeline implementation was inspired by: Social auth core. For more
+    information check their Github repository:
+    https://github.com/python-social-auth/social-core
     """
     functions = get_functions_for_pipeline(pipeline)
 
@@ -69,10 +75,10 @@ def run_pipeline(pipeline, *args, raise_exception=False, **kwargs):
                 )
                 raise exc
         except Exception as exc:  # pylint: disable=broad-except
-            # We're catching this because we don't want the core to blow up when a
-            # hook is broken. This exception will probably need some sort of
-            # monitoring hooked up to it to make sure that these errors don't go
-            # unseen.
+            # We're catching this because we don't want the core to blow up
+            # when a hook is broken. This exception will probably need some
+            # sort of monitoring hooked up to it to make sure that these
+            # errors don't go unseen.
             log.exception(
                 "Exception raised while running '%s': %s\n%s",
                 function.__name__,

--- a/openedx_hooks/filters/pipeline.py
+++ b/openedx_hooks/filters/pipeline.py
@@ -1,0 +1,84 @@
+"""
+Pipeline runner used to execute list of functions (actions or filters).
+"""
+from logging import getLogger
+
+from .exceptions import HookException
+from .utils import get_functions_for_pipeline
+
+log = getLogger(__name__)
+
+
+def run_pipeline(pipeline, *args, raise_exception=False, **kwargs):
+    """
+    Given a list of functions paths, this function  will execute them using the Accumulative Pipeline
+    pattern defined in docs/decisions/0006-hooks-tooling-pipeline.rst
+
+    Example usage:
+        result = run_pipeline(
+            [
+                'my_plugin.hooks.filters.test_function',
+                'my_plugin.hooks.filters.test_function_2nd'
+            ],
+            raise_exception=True,
+            request=request,
+            user=user,
+        )
+        >>> result
+       {
+           'result_test_function': Object,
+           'result_test_function_2nd': Object_2nd,
+       }
+
+    Arguments:
+        pipeline (list): paths where each function is defined.
+
+    Keyword arguments:
+        raise_exception (bool): used to determine whether the pipeline will raise HookExceptions. Default is set
+        to False.
+
+    Returns:
+        out (dict): accumulated outputs of the functions defined in pipeline.
+        result (obj): return object of one of the pipeline functions. This will be the return object for the pipeline
+        if one of the functions returns an object different than Dict o None.
+
+    Exceptions raised:
+        HookException: custom exception re-raised when a function raised an exception of
+        this type and raise_exception is set to True. This behavior is common when using filters.
+
+    This pipeline implementation was inspired by: Social auth core. For more information check their Github
+    repository: https://github.com/python-social-auth/social-core
+    """
+    functions = get_functions_for_pipeline(pipeline)
+
+    out = kwargs.copy()
+    for function in functions:
+        try:
+            result = function(*args, **out) or {}
+            if not isinstance(result, dict):
+                log.info(
+                    "Pipeline stopped by '%s' for returning an object.",
+                    function.__name__,
+                )
+                return result
+            out.update(result)
+        except HookException as exc:
+            if raise_exception:
+                log.exception(
+                    "Exception raised while running '%s':\n %s", function.__name__, exc,
+                )
+                raise exc
+        except Exception as exc:  # pylint: disable=broad-except
+            # We're catching this because we don't want the core to blow up when a
+            # hook is broken. This exception will probably need some sort of
+            # monitoring hooked up to it to make sure that these errors don't go
+            # unseen.
+            log.exception(
+                "Exception raised while running '%s': %s\n%s",
+                function.__name__,
+                exc,
+                "Continuing execution.",
+            )
+            continue
+
+    return out

--- a/openedx_hooks/filters/tests/__init__.py
+++ b/openedx_hooks/filters/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test package for filters from the Hooks Extension Framework.
+"""

--- a/openedx_hooks/filters/tests/test_pipeline.py
+++ b/openedx_hooks/filters/tests/test_pipeline.py
@@ -24,7 +24,7 @@ class TestRunningPipeline(TestCase):
         }
         self.pipeline = Mock()
 
-    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    @patch("openedx_hooks.filters.pipeline.get_functions_for_pipeline")
     def test_run_empty_pipeline(self, get_functions_mock):
         """
         This method runs an empty pipeline, i.e, a pipeline without
@@ -40,7 +40,7 @@ class TestRunningPipeline(TestCase):
         get_functions_mock.assert_called_once_with([])
         self.assertEqual(result, self.kwargs)
 
-    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    @patch("openedx_hooks.filters.pipeline.get_functions_for_pipeline")
     def test_raise_hook_exception(self, get_functions_mock):
         """
         This method runs a pipeline with a function that raises
@@ -63,7 +63,7 @@ class TestRunningPipeline(TestCase):
             captured.records[0].getMessage(), log_message,
         )
 
-    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    @patch("openedx_hooks.filters.pipeline.get_functions_for_pipeline")
     def test_not_raise_hook_exception(self, get_functions_mock):
         """
         This method runs a pipeline with a function that raises
@@ -87,7 +87,7 @@ class TestRunningPipeline(TestCase):
         self.assertEqual(result, return_value)
         function_without_exception.assert_called_once_with(**self.kwargs)
 
-    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    @patch("openedx_hooks.filters.pipeline.get_functions_for_pipeline")
     def test_not_raise_common_exception(self, get_functions_mock):
         """
         This method runs a pipeline with a function that raises a
@@ -120,7 +120,7 @@ class TestRunningPipeline(TestCase):
         self.assertEqual(result, return_value)
         function_without_exception.assert_called_once_with(**self.kwargs)
 
-    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    @patch("openedx_hooks.filters.pipeline.get_functions_for_pipeline")
     def test_getting_pipeline_result(self, get_functions_mock):
         """
         This method runs a pipeline with functions defined via configuration.
@@ -148,7 +148,7 @@ class TestRunningPipeline(TestCase):
         second_function.assert_called_once_with(**return_value_1st)
         self.assertDictEqual(result, return_overall_value)
 
-    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    @patch("openedx_hooks.filters.pipeline.get_functions_for_pipeline")
     def test_partial_pipeline(self, get_functions_mock):
         """
         This method runs a pipeline with functions defined via configuration.

--- a/openedx_hooks/filters/tests/test_pipeline.py
+++ b/openedx_hooks/filters/tests/test_pipeline.py
@@ -27,7 +27,8 @@ class TestRunningPipeline(TestCase):
     @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
     def test_run_empty_pipeline(self, get_functions_mock):
         """
-        This method runs an empty pipeline, i.e, a pipeline without defined functions.
+        This method runs an empty pipeline, i.e, a pipeline without
+        defined functions.
 
         Expected behavior:
             Returns the same input arguments.
@@ -42,7 +43,8 @@ class TestRunningPipeline(TestCase):
     @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
     def test_raise_hook_exception(self, get_functions_mock):
         """
-        This method runs a pipeline with a function that raises HookException.
+        This method runs a pipeline with a function that raises
+        HookException.
 
         Expected behavior:
             The pipeline re-raises the exception caught.
@@ -64,8 +66,8 @@ class TestRunningPipeline(TestCase):
     @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
     def test_not_raise_hook_exception(self, get_functions_mock):
         """
-        This method runs a pipeline with a function that raises HookException but
-        raise_exception is set to False.
+        This method runs a pipeline with a function that raises
+        HookException but raise_exception is set to False.
 
         Expected behavior:
             The pipeline does not re-raise the exception caught.
@@ -88,7 +90,8 @@ class TestRunningPipeline(TestCase):
     @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
     def test_not_raise_common_exception(self, get_functions_mock):
         """
-        This method runs a pipeline with a function that raises a common Exception.
+        This method runs a pipeline with a function that raises a
+        common Exception.
 
         Expected behavior:
             The pipeline continues execution after caughting Exception.
@@ -104,8 +107,8 @@ class TestRunningPipeline(TestCase):
             function_without_exception,
         ]
         log_message = (
-            "Exception raised while running 'function_with_exception': Value error exception\n"
-            "Continuing execution."
+            "Exception raised while running 'function_with_exception': "
+            "Value error exception\nContinuing execution."
         )
 
         with self.assertLogs() as captured:
@@ -162,7 +165,10 @@ class TestRunningPipeline(TestCase):
             first_function,
             second_function,
         ]
-        log_message = "Pipeline stopped by 'first_function' for returning an object."
+        log_message = (
+            "Pipeline stopped by 'first_function' for returning "
+            "an object."
+        )
 
         with self.assertLogs() as captured:
             result = run_pipeline(self.pipeline, **self.kwargs)

--- a/openedx_hooks/filters/tests/test_pipeline.py
+++ b/openedx_hooks/filters/tests/test_pipeline.py
@@ -1,0 +1,175 @@
+"""
+Tests for `edx-django-utils` hooks pipeline.
+"""
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from ..exceptions import HookException
+from ..pipeline import run_pipeline
+
+
+class TestRunningPipeline(TestCase):
+    """
+    Test class to verify standard behavior of the Pipeline runner.
+    """
+
+    def setUp(self):
+        """
+        Setup common conditions for every test case.
+        """
+        super().setUp()
+        self.kwargs = {
+            "request": Mock(),
+        }
+        self.pipeline = Mock()
+
+    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    def test_run_empty_pipeline(self, get_functions_mock):
+        """
+        This method runs an empty pipeline, i.e, a pipeline without defined functions.
+
+        Expected behavior:
+            Returns the same input arguments.
+        """
+        get_functions_mock.return_value = []
+
+        result = run_pipeline([], **self.kwargs)
+
+        get_functions_mock.assert_called_once_with([])
+        self.assertEqual(result, self.kwargs)
+
+    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    def test_raise_hook_exception(self, get_functions_mock):
+        """
+        This method runs a pipeline with a function that raises HookException.
+
+        Expected behavior:
+            The pipeline re-raises the exception caught.
+        """
+        exception_message = "There was an error executing filter X."
+        function = Mock(side_effect=HookException(message=exception_message))
+        function.__name__ = "function_name"
+        get_functions_mock.return_value = [function]
+        log_message = "Exception raised while running '{func_name}':\n HookException: {exc_msg}".format(
+            func_name="function_name", exc_msg=exception_message,
+        )
+
+        with self.assertRaises(HookException), self.assertLogs() as captured:
+            run_pipeline(self.pipeline, raise_exception=True, **self.kwargs)
+        self.assertEqual(
+            captured.records[0].getMessage(), log_message,
+        )
+
+    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    def test_not_raise_hook_exception(self, get_functions_mock):
+        """
+        This method runs a pipeline with a function that raises HookException but
+        raise_exception is set to False.
+
+        Expected behavior:
+            The pipeline does not re-raise the exception caught.
+        """
+        return_value = {
+            "request": Mock(),
+        }
+        function_with_exception = Mock(side_effect=HookException)
+        function_without_exception = Mock(return_value=return_value)
+        get_functions_mock.return_value = [
+            function_with_exception,
+            function_without_exception,
+        ]
+
+        result = run_pipeline(self.pipeline, **self.kwargs)
+
+        self.assertEqual(result, return_value)
+        function_without_exception.assert_called_once_with(**self.kwargs)
+
+    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    def test_not_raise_common_exception(self, get_functions_mock):
+        """
+        This method runs a pipeline with a function that raises a common Exception.
+
+        Expected behavior:
+            The pipeline continues execution after caughting Exception.
+        """
+        return_value = {
+            "request": Mock(),
+        }
+        function_with_exception = Mock(side_effect=ValueError("Value error exception"))
+        function_with_exception.__name__ = "function_with_exception"
+        function_without_exception = Mock(return_value=return_value)
+        get_functions_mock.return_value = [
+            function_with_exception,
+            function_without_exception,
+        ]
+        log_message = (
+            "Exception raised while running 'function_with_exception': Value error exception\n"
+            "Continuing execution."
+        )
+
+        with self.assertLogs() as captured:
+            result = run_pipeline(self.pipeline, **self.kwargs)
+
+        self.assertEqual(
+            captured.records[0].getMessage(), log_message,
+        )
+        self.assertEqual(result, return_value)
+        function_without_exception.assert_called_once_with(**self.kwargs)
+
+    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    def test_getting_pipeline_result(self, get_functions_mock):
+        """
+        This method runs a pipeline with functions defined via configuration.
+
+        Expected behavior:
+            Returns the processed dictionary.
+        """
+        return_value_1st = {
+            "request": Mock(),
+        }
+        return_value_2nd = {
+            "user": Mock(),
+        }
+        return_overall_value = {**return_value_1st, **return_value_2nd}
+        first_function = Mock(return_value=return_value_1st)
+        second_function = Mock(return_value=return_value_2nd)
+        get_functions_mock.return_value = [
+            first_function,
+            second_function,
+        ]
+
+        result = run_pipeline(self.pipeline, **self.kwargs)
+
+        first_function.assert_called_once_with(**self.kwargs)
+        second_function.assert_called_once_with(**return_value_1st)
+        self.assertDictEqual(result, return_overall_value)
+
+    @patch("edx_django_utils.hooks.pipeline.get_functions_for_pipeline")
+    def test_partial_pipeline(self, get_functions_mock):
+        """
+        This method runs a pipeline with functions defined via configuration.
+        At some point, returns an object to stop execution.
+
+        Expected behavior:
+            Returns the object used to stop execution.
+        """
+        return_value_1st = Mock()
+        first_function = Mock(return_value=return_value_1st)
+        first_function.__name__ = "first_function"
+        second_function = Mock()
+        get_functions_mock.return_value = [
+            first_function,
+            second_function,
+        ]
+        log_message = "Pipeline stopped by 'first_function' for returning an object."
+
+        with self.assertLogs() as captured:
+            result = run_pipeline(self.pipeline, **self.kwargs)
+
+        self.assertEqual(
+            captured.records[0].getMessage(), log_message,
+        )
+        first_function.assert_called_once_with(**self.kwargs)
+        second_function.assert_not_called()
+        self.assertEqual(result, return_value_1st)

--- a/openedx_hooks/filters/tests/test_triggers.py
+++ b/openedx_hooks/filters/tests/test_triggers.py
@@ -1,0 +1,60 @@
+"""
+Tests for `edx-django-utils` hooks triggers.
+"""
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from ..triggers import trigger_filter
+
+
+class TestTriggerFilter(TestCase):
+    """
+    Test class to verify standard behavior of trigger_filter.
+    """
+
+    def setUp(self):
+        """
+        Setup common conditions for every test case.
+        """
+        super().setUp()
+        self.kwargs = {
+            "request": Mock(),
+        }
+
+    @patch("edx_django_utils.hooks.triggers.run_pipeline")
+    @patch("edx_django_utils.hooks.triggers.get_pipeline_configuration")
+    def test_run_empty_pipeline(self, get_configuration_mock, run_pipeline_mock):
+        """
+        This method runs trigget_filter with an empty pipeline.
+
+        Expected behavior:
+            Returns keyword arguments without calling the pipeline runner.
+        """
+        get_configuration_mock.return_value = []
+
+        result = trigger_filter("trigger_name", **self.kwargs)
+
+        self.assertDictEqual(result, self.kwargs)
+        run_pipeline_mock.assert_not_called()
+
+    @patch("edx_django_utils.hooks.triggers.run_pipeline")
+    @patch("edx_django_utils.hooks.triggers.get_pipeline_configuration")
+    def test_affecting_execution(self, get_configuration_mock, run_pipeline_mock):
+        """
+        This method runs trigget_filter affecting the application flow raising exceptions.
+
+        Expected behavior:
+            Run pipeline is called with raise_exception equals to True.
+            Also, given that by default filters are synchronous, then get_pipeline_configuration is
+            called with async_default equals to False.
+        """
+        pipeline = Mock()
+        get_configuration_mock.return_value = pipeline
+
+        trigger_filter("trigger_name", **self.kwargs)
+
+        get_configuration_mock.assert_called_once_with("trigger_name")
+        run_pipeline_mock.assert_called_once_with(
+            pipeline, raise_exception=True, **self.kwargs
+        )

--- a/openedx_hooks/filters/tests/test_triggers.py
+++ b/openedx_hooks/filters/tests/test_triggers.py
@@ -42,12 +42,14 @@ class TestTriggerFilter(TestCase):
     @patch("edx_django_utils.hooks.triggers.get_pipeline_configuration")
     def test_affecting_execution(self, get_configuration_mock, run_pipeline_mock):
         """
-        This method runs trigget_filter affecting the application flow raising exceptions.
+        This method runs trigget_filter affecting the application flow
+        raising exceptions.
 
         Expected behavior:
             Run pipeline is called with raise_exception equals to True.
-            Also, given that by default filters are synchronous, then get_pipeline_configuration is
-            called with async_default equals to False.
+            Also, given that by default filters are synchronous,
+            then get_pipeline_configuration is called with async_default equals
+            to False.
         """
         pipeline = Mock()
         get_configuration_mock.return_value = pipeline

--- a/openedx_hooks/filters/tests/test_triggers.py
+++ b/openedx_hooks/filters/tests/test_triggers.py
@@ -22,8 +22,8 @@ class TestTriggerFilter(TestCase):
             "request": Mock(),
         }
 
-    @patch("edx_django_utils.hooks.triggers.run_pipeline")
-    @patch("edx_django_utils.hooks.triggers.get_pipeline_configuration")
+    @patch("openedx_hooks.filters.triggers.run_pipeline")
+    @patch("openedx_hooks.filters.triggers.get_pipeline_configuration")
     def test_run_empty_pipeline(self, get_configuration_mock, run_pipeline_mock):
         """
         This method runs trigget_filter with an empty pipeline.
@@ -38,8 +38,8 @@ class TestTriggerFilter(TestCase):
         self.assertDictEqual(result, self.kwargs)
         run_pipeline_mock.assert_not_called()
 
-    @patch("edx_django_utils.hooks.triggers.run_pipeline")
-    @patch("edx_django_utils.hooks.triggers.get_pipeline_configuration")
+    @patch("openedx_hooks.filters.triggers.run_pipeline")
+    @patch("openedx_hooks.filters.triggers.get_pipeline_configuration")
     def test_affecting_execution(self, get_configuration_mock, run_pipeline_mock):
         """
         This method runs trigget_filter affecting the application flow

--- a/openedx_hooks/filters/tests/test_utils.py
+++ b/openedx_hooks/filters/tests/test_utils.py
@@ -1,0 +1,188 @@
+"""
+Tests for the `edx-django-utils` hooks utilities.
+"""
+from unittest.mock import patch
+
+import ddt
+from django.test import TestCase, override_settings
+
+from ..utils import get_functions_for_pipeline, get_hook_configurations, get_pipeline_configuration
+
+
+def test_function():
+    """
+    Utility function used when getting functions for pipeline.
+    """
+
+
+@ddt.ddt
+class TestUtilityFunctions(TestCase):
+    """
+    Test class to verify standard behavior of hooks utility functions.
+    """
+
+    def test_get_empty_function_list(self):
+        """
+        This method is used to verify the behavior of get_functions_for_pipeline
+        when an empty pipeline is passed as argument.
+
+        Expected behavior:
+            Returns an empty list.
+        """
+        pipeline = []
+
+        function_list = get_functions_for_pipeline(pipeline)
+
+        self.assertEqual(function_list, pipeline)
+
+    def test_get_non_existing_function(self):
+        """
+        This method is used to verify the behavior of get_functions_for_pipeline
+        when a non-existing function path is passed inside the pipeline argument.
+
+        Expected behavior:
+            Returns a list without the non-existing function.
+        """
+        pipeline = [
+            "edx_django_utils.hooks.tests.test_utils.test_function",
+            "edx_django_utils.hooks.tests.test_utils.non_existent",
+        ]
+        log_message = "Failed to import '{}'.".format(
+            "edx_django_utils.hooks.tests.test_utils.non_existent"
+        )
+
+        with self.assertLogs() as captured:
+            function_list = get_functions_for_pipeline(pipeline)
+
+        self.assertEqual(
+            captured.records[0].getMessage(), log_message,
+        )
+        self.assertEqual(function_list, [test_function])
+
+    def test_get_non_existing_module_func(self):
+        """
+        This method is used to verify the behavior of get_functions_for_pipeline
+        when a non-existing module path is passed inside the pipeline argument.
+
+        Expected behavior:
+            Returns a list without the non-existing function.
+        """
+        pipeline = [
+            "edx_django_utils.hooks.tests.test_utils.test_function",
+            "edx_django_utils.hooks.non_existent.test_utils.test_function",
+        ]
+        log_message = "Failed to import '{}'.".format(
+            "edx_django_utils.hooks.non_existent.test_utils.test_function"
+        )
+
+        with self.assertLogs() as captured:
+            function_list = get_functions_for_pipeline(pipeline)
+
+        self.assertEqual(captured.records[0].getMessage(), log_message)
+        self.assertEqual(function_list, [test_function])
+
+    def test_get_function_list(self):
+        """
+        This method is used to verify the behavior of get_functions_for_pipeline
+        when a list of functions paths is passed as the pipeline parameter.
+
+        Expected behavior:
+            Returns a list with the function objects.
+        """
+        pipeline = [
+            "edx_django_utils.hooks.tests.test_utils.test_function",
+            "edx_django_utils.hooks.tests.test_utils.test_function",
+        ]
+
+        function_list = get_functions_for_pipeline(pipeline)
+
+        self.assertEqual(function_list, [test_function] * 2)
+
+    def test_get_empty_hook_config(self):
+        """
+        This method is used to verify the behavior of get_hook_configurations
+        when a trigger without a HOOKS_EXTENSION_CONFIG is passed as parameter.
+
+        Expected behavior:
+            Returns an empty dictionary.
+        """
+        result = get_hook_configurations("trigger_name")
+
+        self.assertEqual(result, {})
+
+    @override_settings(
+        HOOKS_EXTENSION_CONFIG={
+            "trigger_name": {
+                "pipeline": [
+                    "edx_django_utils.hooks.tests.test_utils.test_function",
+                    "edx_django_utils.hooks.tests.test_utils.test_function",
+                ],
+                "async": False,
+            }
+        }
+    )
+    def test_get_hook_config(self):
+        """
+        This method is used to verify the behavior of get_hook_configurations
+        when a trigger with HOOKS_EXTENSION_CONFIG defined is passed as parameter.
+
+        Expected behavior:
+            Returns a tuple with pipeline configurations.
+        """
+        expected_result = {
+            "pipeline": [
+                "edx_django_utils.hooks.tests.test_utils.test_function",
+                "edx_django_utils.hooks.tests.test_utils.test_function",
+            ],
+            "async": False,
+        }
+
+        result = get_hook_configurations("trigger_name")
+
+        self.assertDictEqual(result, expected_result)
+
+    @patch("edx_django_utils.hooks.utils.get_hook_configurations")
+    @ddt.data(
+        (("edx_django_utils.hooks.tests.test_utils.test_function",), []),
+        ({}, []),
+        (
+            {
+                "pipeline": [
+                    "edx_django_utils.hooks.tests.test_utils.test_function",
+                    "edx_django_utils.hooks.tests.test_utils.test_function",
+                ],
+            },
+            [
+                "edx_django_utils.hooks.tests.test_utils.test_function",
+                "edx_django_utils.hooks.tests.test_utils.test_function",
+            ],
+        ),
+        (
+            [
+                "edx_django_utils.hooks.tests.test_utils.test_function",
+                "edx_django_utils.hooks.tests.test_utils.test_function",
+            ],
+            [
+                "edx_django_utils.hooks.tests.test_utils.test_function",
+                "edx_django_utils.hooks.tests.test_utils.test_function",
+            ],
+        ),
+        (
+            "edx_django_utils.hooks.tests.test_utils.test_function",
+            ["edx_django_utils.hooks.tests.test_utils.test_function", ],
+        ),
+    )
+    @ddt.unpack
+    def test_get_pipeline_config(self, config, expected_result, get_config_mock):
+        """
+        This method is used to verify the behavior of get_pipeline_configuration
+        when a trigger with HOOKS_EXTENSION_CONFIG defined is passed as parameter.
+
+        Expected behavior:
+            Returns a tuple with the pipeline and synchronous configuration.
+        """
+        get_config_mock.return_value = config
+
+        result = get_pipeline_configuration("trigger_name")
+
+        self.assertListEqual(result, expected_result)

--- a/openedx_hooks/filters/tests/test_utils.py
+++ b/openedx_hooks/filters/tests/test_utils.py
@@ -23,8 +23,9 @@ class TestUtilityFunctions(TestCase):
 
     def test_get_empty_function_list(self):
         """
-        This method is used to verify the behavior of get_functions_for_pipeline
-        when an empty pipeline is passed as argument.
+        This method is used to verify the behavior of
+        get_functions_for_pipeline when an empty pipeline is
+        passed as argument.
 
         Expected behavior:
             Returns an empty list.
@@ -37,8 +38,9 @@ class TestUtilityFunctions(TestCase):
 
     def test_get_non_existing_function(self):
         """
-        This method is used to verify the behavior of get_functions_for_pipeline
-        when a non-existing function path is passed inside the pipeline argument.
+        This method is used to verify the behavior of
+        get_functions_for_pipeline when a non-existing function
+        path is passed inside the pipeline argument.
 
         Expected behavior:
             Returns a list without the non-existing function.
@@ -61,8 +63,9 @@ class TestUtilityFunctions(TestCase):
 
     def test_get_non_existing_module_func(self):
         """
-        This method is used to verify the behavior of get_functions_for_pipeline
-        when a non-existing module path is passed inside the pipeline argument.
+        This method is used to verify the behavior of
+        get_functions_for_pipeline when a non-existing module
+        path is passed inside the pipeline argument.
 
         Expected behavior:
             Returns a list without the non-existing function.
@@ -83,8 +86,9 @@ class TestUtilityFunctions(TestCase):
 
     def test_get_function_list(self):
         """
-        This method is used to verify the behavior of get_functions_for_pipeline
-        when a list of functions paths is passed as the pipeline parameter.
+        This method is used to verify the behavior of
+        get_functions_for_pipeline when a list of functions
+        paths is passed as the pipeline parameter.
 
         Expected behavior:
             Returns a list with the function objects.
@@ -100,8 +104,9 @@ class TestUtilityFunctions(TestCase):
 
     def test_get_empty_hook_config(self):
         """
-        This method is used to verify the behavior of get_hook_configurations
-        when a trigger without a HOOKS_EXTENSION_CONFIG is passed as parameter.
+        This method is used to verify the behavior of
+        get_hook_configurations when a trigger without a
+        HOOKS_EXTENSION_CONFIG is passed as parameter.
 
         Expected behavior:
             Returns an empty dictionary.
@@ -123,8 +128,9 @@ class TestUtilityFunctions(TestCase):
     )
     def test_get_hook_config(self):
         """
-        This method is used to verify the behavior of get_hook_configurations
-        when a trigger with HOOKS_EXTENSION_CONFIG defined is passed as parameter.
+        This method is used to verify the behavior of
+        get_hook_configurations when a trigger with
+        HOOKS_EXTENSION_CONFIG defined is passed as parameter.
 
         Expected behavior:
             Returns a tuple with pipeline configurations.
@@ -175,11 +181,13 @@ class TestUtilityFunctions(TestCase):
     @ddt.unpack
     def test_get_pipeline_config(self, config, expected_result, get_config_mock):
         """
-        This method is used to verify the behavior of get_pipeline_configuration
-        when a trigger with HOOKS_EXTENSION_CONFIG defined is passed as parameter.
+        This method is used to verify the behavior of
+        get_pipeline_configuration when a trigger with
+        HOOKS_EXTENSION_CONFIG defined is passed as parameter.
 
         Expected behavior:
-            Returns a tuple with the pipeline and synchronous configuration.
+            Returns a tuple with the pipeline and synchronous
+            configuration.
         """
         get_config_mock.return_value = config
 

--- a/openedx_hooks/filters/tests/test_utils.py
+++ b/openedx_hooks/filters/tests/test_utils.py
@@ -46,11 +46,11 @@ class TestUtilityFunctions(TestCase):
             Returns a list without the non-existing function.
         """
         pipeline = [
-            "edx_django_utils.hooks.tests.test_utils.test_function",
-            "edx_django_utils.hooks.tests.test_utils.non_existent",
+            "openedx_hooks.filters.tests.test_utils.test_function",
+            "openedx_hooks.filters.tests.test_utils.non_existent",
         ]
         log_message = "Failed to import '{}'.".format(
-            "edx_django_utils.hooks.tests.test_utils.non_existent"
+            "openedx_hooks.filters.tests.test_utils.non_existent"
         )
 
         with self.assertLogs() as captured:
@@ -71,11 +71,11 @@ class TestUtilityFunctions(TestCase):
             Returns a list without the non-existing function.
         """
         pipeline = [
-            "edx_django_utils.hooks.tests.test_utils.test_function",
-            "edx_django_utils.hooks.non_existent.test_utils.test_function",
+            "openedx_hooks.filters.tests.test_utils.test_function",
+            "openedx_hooks.filters.non_existent.test_utils.test_function",
         ]
         log_message = "Failed to import '{}'.".format(
-            "edx_django_utils.hooks.non_existent.test_utils.test_function"
+            "openedx_hooks.filters.non_existent.test_utils.test_function"
         )
 
         with self.assertLogs() as captured:
@@ -94,8 +94,8 @@ class TestUtilityFunctions(TestCase):
             Returns a list with the function objects.
         """
         pipeline = [
-            "edx_django_utils.hooks.tests.test_utils.test_function",
-            "edx_django_utils.hooks.tests.test_utils.test_function",
+            "openedx_hooks.filters.tests.test_utils.test_function",
+            "openedx_hooks.filters.tests.test_utils.test_function",
         ]
 
         function_list = get_functions_for_pipeline(pipeline)
@@ -119,8 +119,8 @@ class TestUtilityFunctions(TestCase):
         HOOKS_EXTENSION_CONFIG={
             "trigger_name": {
                 "pipeline": [
-                    "edx_django_utils.hooks.tests.test_utils.test_function",
-                    "edx_django_utils.hooks.tests.test_utils.test_function",
+                    "openedx_hooks.filters.tests.test_utils.test_function",
+                    "openedx_hooks.filters.tests.test_utils.test_function",
                 ],
                 "async": False,
             }
@@ -137,8 +137,8 @@ class TestUtilityFunctions(TestCase):
         """
         expected_result = {
             "pipeline": [
-                "edx_django_utils.hooks.tests.test_utils.test_function",
-                "edx_django_utils.hooks.tests.test_utils.test_function",
+                "openedx_hooks.filters.tests.test_utils.test_function",
+                "openedx_hooks.filters.tests.test_utils.test_function",
             ],
             "async": False,
         }
@@ -147,35 +147,35 @@ class TestUtilityFunctions(TestCase):
 
         self.assertDictEqual(result, expected_result)
 
-    @patch("edx_django_utils.hooks.utils.get_hook_configurations")
+    @patch("openedx_hooks.filters.utils.get_hook_configurations")
     @ddt.data(
-        (("edx_django_utils.hooks.tests.test_utils.test_function",), []),
+        (("openedx_hooks.filters.tests.test_utils.test_function",), []),
         ({}, []),
         (
             {
                 "pipeline": [
-                    "edx_django_utils.hooks.tests.test_utils.test_function",
-                    "edx_django_utils.hooks.tests.test_utils.test_function",
+                    "openedx_hooks.filters.tests.test_utils.test_function",
+                    "openedx_hooks.filters.tests.test_utils.test_function",
                 ],
             },
             [
-                "edx_django_utils.hooks.tests.test_utils.test_function",
-                "edx_django_utils.hooks.tests.test_utils.test_function",
+                "openedx_hooks.filters.tests.test_utils.test_function",
+                "openedx_hooks.filters.tests.test_utils.test_function",
             ],
         ),
         (
             [
-                "edx_django_utils.hooks.tests.test_utils.test_function",
-                "edx_django_utils.hooks.tests.test_utils.test_function",
+                "openedx_hooks.filters.tests.test_utils.test_function",
+                "openedx_hooks.filters.tests.test_utils.test_function",
             ],
             [
-                "edx_django_utils.hooks.tests.test_utils.test_function",
-                "edx_django_utils.hooks.tests.test_utils.test_function",
+                "openedx_hooks.filters.tests.test_utils.test_function",
+                "openedx_hooks.filters.tests.test_utils.test_function",
             ],
         ),
         (
-            "edx_django_utils.hooks.tests.test_utils.test_function",
-            ["edx_django_utils.hooks.tests.test_utils.test_function", ],
+            "openedx_hooks.filters.tests.test_utils.test_function",
+            ["openedx_hooks.filters.tests.test_utils.test_function", ],
         ),
     )
     @ddt.unpack

--- a/openedx_hooks/filters/triggers.py
+++ b/openedx_hooks/filters/triggers.py
@@ -7,8 +7,9 @@ from .utils import get_pipeline_configuration
 
 def trigger_filter(trigger_name, *args, **kwargs):
     """
-    Function that manages the execution of filters listening on a trigger. The execution
-    follows the Pipeline pattern using the pipeline runner.
+    Manage the execution of filters listening on a trigger.
+
+    The execution follows the Pipeline pattern using the pipeline runner.
 
     Example usage:
         result = trigger_filter(
@@ -23,12 +24,13 @@ def trigger_filter(trigger_name, *args, **kwargs):
        }
 
     Arguments:
-        trigger_name (str): determines which trigger we are listening to. It also specifies which
-        hook configuration to use when calling trigger_filter.
+        trigger_name (str): determines which trigger we are listening to.
+        It also specifies which hook configuration to use when calling
+        trigger_filter.
 
     Returns:
-        result (dict): result of the pipeline execution, i.e the accumulated output of the filters defined in
-        the hooks configuration.
+        result (dict): result of the pipeline execution, i.e the accumulated
+        output of the filters defined in the hooks configuration.
     """
     pipeline = get_pipeline_configuration(trigger_name)
 

--- a/openedx_hooks/filters/triggers.py
+++ b/openedx_hooks/filters/triggers.py
@@ -1,0 +1,38 @@
+"""
+Triggers for actions and filters.
+"""
+from .pipeline import run_pipeline
+from .utils import get_pipeline_configuration
+
+
+def trigger_filter(trigger_name, *args, **kwargs):
+    """
+    Function that manages the execution of filters listening on a trigger. The execution
+    follows the Pipeline pattern using the pipeline runner.
+
+    Example usage:
+        result = trigger_filter(
+            'trigger_name_used_in_hooks_config',
+            request,
+            user=user,
+        )
+        >>> result
+       {
+           'result_test_function': Object,
+           'result_test_function_2nd': Object_2nd,
+       }
+
+    Arguments:
+        trigger_name (str): determines which trigger we are listening to. It also specifies which
+        hook configuration to use when calling trigger_filter.
+
+    Returns:
+        result (dict): result of the pipeline execution, i.e the accumulated output of the filters defined in
+        the hooks configuration.
+    """
+    pipeline = get_pipeline_configuration(trigger_name)
+
+    if not pipeline:
+        return kwargs
+
+    return run_pipeline(pipeline, *args, raise_exception=True, **kwargs)

--- a/openedx_hooks/filters/utils.py
+++ b/openedx_hooks/filters/utils.py
@@ -11,11 +11,18 @@ log = getLogger(__name__)
 
 def get_functions_for_pipeline(pipeline):
     """
-    Helper function that given a pipeline with functions paths gets the objects related
-    to each path.
+    Get function objects from paths.
+
+    Helper function that given a pipeline with functions paths gets
+    the objects related to each path.
 
     Example usage:
-        functions = get_functions_for_pipeline(['1st_path_to_function', ...])
+        functions = get_functions_for_pipeline(
+            [
+                '1st_path_to_function',
+                ...
+            ]
+        )
         >>> functions
         [
             <function 1st_function at 0x00000000000>,
@@ -42,8 +49,11 @@ def get_functions_for_pipeline(pipeline):
 
 def get_pipeline_configuration(trigger_name):
     """
-    Helper function used to get the configuration needed to execute the Pipeline Runner.
-    It will take from the hooks configuration the ist of functions to execute and how to execute them.
+    Get pipeline configuration from filter settings.
+
+    Helper function used to get the configuration needed to execute
+    the Pipeline Runner. It will take from the hooks configuration
+    the list of functions to execute and how to execute them.
 
     Example usage:
         pipeline_config = get_pipeline_configuration('trigger')
@@ -56,10 +66,12 @@ def get_pipeline_configuration(trigger_name):
             )
 
     Arguments:
-        trigger_name (str): determines which is the trigger of this pipeline.
+        trigger_name (str): determines which is the trigger of this
+        pipeline.
 
     Returns:
-        pipeline (list): paths where functions for the pipeline are defined.
+        pipeline (list): paths where functions for the pipeline are
+        defined.
     """
     hook_config = get_hook_configurations(trigger_name)
 
@@ -82,7 +94,10 @@ def get_pipeline_configuration(trigger_name):
 
 def get_hook_configurations(trigger_name):
     """
-    Helper function used to get configuration needed for using Hooks Extension Framework.
+    Get filters configuration from settings.
+
+    Helper function used to get configuration needed for using
+    Hooks Extension Framework.
 
     Example usage:
             configuration = get_hook_configurations('trigger')
@@ -99,7 +114,8 @@ def get_hook_configurations(trigger_name):
         trigger_name (str): determines which configuration to use.
 
     Returns:
-        hooks configuration (dict): taken from Django settings containing hooks configuration.
+        hooks configuration (dict): taken from Django settings
+        containing hooks configuration.
     """
     hooks_config = getattr(settings, "HOOKS_EXTENSION_CONFIG", {})
 

--- a/openedx_hooks/filters/utils.py
+++ b/openedx_hooks/filters/utils.py
@@ -1,0 +1,106 @@
+"""
+Utilities for the hooks module.
+"""
+from logging import getLogger
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+log = getLogger(__name__)
+
+
+def get_functions_for_pipeline(pipeline):
+    """
+    Helper function that given a pipeline with functions paths gets the objects related
+    to each path.
+
+    Example usage:
+        functions = get_functions_for_pipeline(['1st_path_to_function', ...])
+        >>> functions
+        [
+            <function 1st_function at 0x00000000000>,
+            <function 2nd_function at 0x00000000001>,
+            ...
+        ]
+
+    Arguments:
+        pipeline (list): paths where functions are defined.
+
+    Returns:
+        function_list (list): function objects defined in pipeline.
+    """
+    function_list = []
+    for function_path in pipeline:
+        try:
+            function = import_string(function_path)
+            function_list.append(function)
+        except ImportError:
+            log.exception("Failed to import '%s'.", function_path)
+
+    return function_list
+
+
+def get_pipeline_configuration(trigger_name):
+    """
+    Helper function used to get the configuration needed to execute the Pipeline Runner.
+    It will take from the hooks configuration the ist of functions to execute and how to execute them.
+
+    Example usage:
+        pipeline_config = get_pipeline_configuration('trigger')
+        >>> pipeline_config
+            (
+                [
+                    'my_plugin.hooks.filters.test_function',
+                    'my_plugin.hooks.filters.test_function_2nd',
+                ],
+            )
+
+    Arguments:
+        trigger_name (str): determines which is the trigger of this pipeline.
+
+    Returns:
+        pipeline (list): paths where functions for the pipeline are defined.
+    """
+    hook_config = get_hook_configurations(trigger_name)
+
+    if not hook_config:
+        return []
+
+    pipeline = []
+
+    if isinstance(hook_config, dict):
+        pipeline = hook_config.get("pipeline", [])
+
+    elif isinstance(hook_config, list):
+        pipeline = hook_config
+
+    elif isinstance(hook_config, str):
+        pipeline.append(hook_config)
+
+    return pipeline
+
+
+def get_hook_configurations(trigger_name):
+    """
+    Helper function used to get configuration needed for using Hooks Extension Framework.
+
+    Example usage:
+            configuration = get_hook_configurations('trigger')
+            >>> configuration
+            {
+                'pipeline':
+                    [
+                        'my_plugin.hooks.filters.test_function',
+                        'my_plugin.hooks.filters.test_function_2nd',
+                    ],
+            }
+
+    Arguments:
+        trigger_name (str): determines which configuration to use.
+
+    Returns:
+        hooks configuration (dict): taken from Django settings containing hooks configuration.
+    """
+    hooks_config = getattr(settings, "HOOKS_EXTENSION_CONFIG", {})
+
+    return hooks_config.get(trigger_name, {})

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -42,5 +42,5 @@ tox==3.23.0
     # via -r requirements/ci.in
 urllib3==1.26.4
     # via requests
-virtualenv==20.4.3
+virtualenv==20.4.4
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ asgiref==3.3.4
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.5.2
+astroid==2.5.3
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -72,6 +72,8 @@ cryptography==3.4.7
     # via
     #   -r requirements/quality.txt
     #   secretstorage
+ddt==1.4.2
+    # via -r requirements/quality.txt
 diff-cover==5.0.1
     # via -r requirements/dev.in
 distlib==0.3.1
@@ -83,7 +85,7 @@ django==3.2
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-lint
-docutils==0.17
+docutils==0.17.1
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -99,7 +101,7 @@ idna==2.10
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==3.10.0
+importlib-metadata==4.0.1
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -158,7 +160,7 @@ pep517==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.0.1
+pip-tools==6.1.0
     # via -r requirements/pip-tools.txt
 pkginfo==1.7.0
     # via
@@ -194,7 +196,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -217,7 +219,7 @@ pyparsing==2.4.7
     #   packaging
 pytest-cov==2.11.1
     # via -r requirements/quality.txt
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/quality.txt
 pytest==6.2.3
     # via
@@ -310,7 +312,7 @@ urllib3==1.26.4
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-virtualenv==20.4.3
+virtualenv==20.4.4
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -34,13 +34,15 @@ coverage==5.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
+ddt==1.4.2
+    # via -r requirements/test.txt
 django==3.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
 doc8==0.8.1
     # via -r requirements/doc.in
-docutils==0.17
+docutils==0.16
     # via
     #   doc8
     #   readme-renderer
@@ -94,7 +96,7 @@ pyparsing==2.4.7
     #   packaging
 pytest-cov==2.11.1
     # via -r requirements/test.txt
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/test.txt
 pytest==6.2.3
     # via
@@ -128,7 +130,7 @@ six==1.15.0
     #   readme-renderer
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==3.5.3
+sphinx==3.5.4
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==7.1.2
     # via pip-tools
 pep517==0.10.0
     # via pip-tools
-pip-tools==6.0.1
+pip-tools==6.1.0
     # via -r requirements/pip-tools.in
 toml==0.10.2
     # via pep517

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.36.2
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.0.1
     # via -r requirements/pip.in
-setuptools==54.2.0
+setuptools==56.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.3.4
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.5.2
+astroid==2.5.3
     # via
     #   pylint
     #   pylint-celery
@@ -44,18 +44,20 @@ coverage==5.5
     #   pytest-cov
 cryptography==3.4.7
     # via secretstorage
+ddt==1.4.2
+    # via -r requirements/test.txt
 django==3.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-lint
-docutils==0.17
+docutils==0.17.1
     # via readme-renderer
 edx-lint==5.0.0
     # via -r requirements/quality.in
 idna==2.10
     # via requests
-importlib-metadata==3.10.0
+importlib-metadata==4.0.1
     # via
     #   keyring
     #   twine
@@ -114,7 +116,7 @@ pygments==2.8.1
     # via readme-renderer
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.3
     # via edx-lint
 pylint-plugin-utils==0.6
     # via
@@ -132,7 +134,7 @@ pyparsing==2.4.7
     #   packaging
 pytest-cov==2.11.1
     # via -r requirements/test.txt
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/test.txt
 pytest==6.2.3
     # via

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,6 +3,7 @@
 
 -r base.txt               # Core dependencies for this package
 
+ddt                       # A library to multiply test cases
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 code-annotations          # provides commands used by the pii_check make target.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,6 +16,8 @@ code-annotations==1.1.1
     # via -r requirements/test.in
 coverage==5.5
     # via pytest-cov
+ddt==1.4.2
+    # via -r requirements/test.in
 django==3.2
     # via
     #   -r requirements/base.txt
@@ -38,7 +40,7 @@ pyparsing==2.4.7
     # via packaging
 pytest-cov==2.11.1
     # via -r requirements/test.in
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/test.in
 pytest==6.2.3
     # via

--- a/test_utils/test_settings.py
+++ b/test_utils/test_settings.py
@@ -1,0 +1,31 @@
+
+"""
+These settings are here to use during tests, because django requires them.
+
+In a real-world use case, apps in this project are installed into other
+Django applications, so these settings will not be used.
+"""
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "default.db",
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+    },
+    "read_replica": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "read_replica.db",
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+    },
+}
+
+
+INSTALLED_APPS = (
+    "openedx_hooks",
+)

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ commands =
 
 [testenv:docs]
 setenv =
+    DJANGO_SETTINGS_MODULE = test_utils.test_settings
     PYTHONPATH = {toxinidir}
 whitelist_externals =
     make

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ ignore = D101,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D
 
 
 [pytest]
+DJANGO_SETTINGS_MODULE = test_utils.test_settings
 addopts = --cov openedx_hooks --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements site-packages
 
@@ -69,7 +70,7 @@ commands =
 
 [testenv:pii_check]
 setenv =
-    DJANGO_SETTINGS_MODULE = test_settings
+    DJANGO_SETTINGS_MODULE = test_utils.test_settings
 deps =
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
**Description:** 

This PR adds a new module for the tools needed by the Hooks Extension Framework to execute filters. This project is described in more depth in the OEP-50. 

This tooling will allow us to extend the platform by adding triggers in specific places, those triggers will be able to execute a list of filters previously configured. 

For that to happen, we are introducing two functions called `triggers_filter`. When called, these functions will execute a Pipeline with the list of functions specified by the configuration. This pipeline is defined in [ADR Hooks tooling: pipeline](https://github.com/eduNEXT/edx-django-utils/blob/17875b577d99cf82799705b07c8c1f29633898ce/docs/decisions/0006-hooks-tooling-pipeline.rst)

Now, this configuration as indicated in [ADR: Configuration for the Hook Extension Framework](https://github.com/eduNEXT/edx-django-utils/blob/17875b577d99cf82799705b07c8c1f29633898ce/docs/decisions/0005-hooks-config-location.rst) is defined using Django settings and looks like this (extended format):
```
HOOKS_EXTENSION_CONFIG = {
      "openedx.lms.module.some_trigger.filter.v1": {
               "pipeline": [
                     "somelibrary.filters.1st_function",
                     "other_library.filters.2nd_function"
                     ],
     },
```
`Pipeline` is the list of functions that the pipeline runner will execute, please, check out the ADR where the other configuration formats are defined.

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Run `make lms-shell`
2. Inside the shell run: 
    `pip install -e git+https://github.com/edx/edx-django-utils.git@MJG/hooks_pipeline_tool#egg=edx_django_utils`
3. Run `pip install -e https://github.com/eduNEXT/openedx-basic-hooks.git`, you can also use your own test library. Here are defined the functions that will be executed by a trigger. 
4. [Here's](https://github.com/eduNEXT/edx-platform/pull/210/files) a quick and dirty way to create and use triggers on edx-platform. We defined three triggers and the configuration needed to use this framework. PENDING: add link to the PR against edx-platform that includes the first implementation of a trigger. 
5. (Optional) If you're using our demo and sample openedx-hooks-library, you have a trigger_filter ready to be used. What you'll have to do is execute the logic that the hook extended, for example: 
- Go to register
- Enter data for registration and in the field `Year of birth` add 2020.
- Then, an error will be displayed caused by the HookException raised by our filter function defined in https://github.com/eduNEXT/openedx-basic-hooks/blob/5f2cf73a06d34506a82f40d6e33be2b41019ef66/openedx_basic_hooks/filters/pre_register.py#L13 

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
